### PR TITLE
Remove github.com/pkg/errors dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
 	github.com/dustin/go-humanize v1.0.1
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sys v0.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WA
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -18,13 +18,12 @@ package z
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"sort"
 	"sync/atomic"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -223,8 +222,8 @@ func (b *Buffer) Grow(n int) {
 	case UseMmap:
 		// Truncate and remap the underlying file.
 		if err := b.mmapFile.Truncate(int64(b.curSz)); err != nil {
-			err = errors.Wrapf(err,
-				"while trying to truncate file: %s to size: %d", b.mmapFile.Fd.Name(), b.curSz)
+			err = errors.Join(err,
+				fmt.Errorf("while trying to truncate file: %s to size: %d", b.mmapFile.Fd.Name(), b.curSz))
 			panic(err)
 		}
 		b.buf = b.mmapFile.Data
@@ -348,7 +347,7 @@ func (s *sortHelper) sortSmall(start, end int) {
 
 func assert(b bool) {
 	if !b {
-		log.Fatalf("%+v", errors.Errorf("Assertion failure"))
+		log.Fatalf("%+v", errors.New("Assertion failure"))
 	}
 }
 func check(err error) {
@@ -534,11 +533,11 @@ func (b *Buffer) Release() error {
 		}
 		path := b.mmapFile.Fd.Name()
 		if err := b.mmapFile.Close(-1); err != nil {
-			return errors.Wrapf(err, "while closing file: %s", path)
+			return errors.Join(err, fmt.Errorf("while closing file: %s", path))
 		}
 		if !b.persistent {
 			if err := os.Remove(path); err != nil {
-				return errors.Wrapf(err, "while deleting file %s", path)
+				return errors.Join(err, fmt.Errorf("while deleting file %s", path))
 			}
 		}
 	}

--- a/z/flags.go
+++ b/z/flags.go
@@ -1,6 +1,7 @@
 package z
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -10,8 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // SuperFlagHelp makes it really easy to generate command line `--help` output for a SuperFlag. For
@@ -204,9 +203,9 @@ func (sf *SuperFlag) GetBool(opt string) bool {
 	}
 	b, err := strconv.ParseBool(val)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as bool for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as bool for key: %s. Options: %s\n",
+				val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return b
@@ -219,9 +218,9 @@ func (sf *SuperFlag) GetFloat64(opt string) float64 {
 	}
 	f, err := strconv.ParseFloat(val, 64)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as float64 for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as float64 for key: %s. Options: %s\n",
+				val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return f
@@ -234,9 +233,9 @@ func (sf *SuperFlag) GetInt64(opt string) int64 {
 	}
 	i, err := strconv.ParseInt(val, 0, 64)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as int64 for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as int64 for key: %s. Options: %s\n",
+				val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return i
@@ -249,9 +248,9 @@ func (sf *SuperFlag) GetUint64(opt string) uint64 {
 	}
 	u, err := strconv.ParseUint(val, 0, 64)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as uint64 for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as uint64 for key: %s. Options: %s\n",
+				val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return u
@@ -264,9 +263,9 @@ func (sf *SuperFlag) GetUint32(opt string) uint32 {
 	}
 	u, err := strconv.ParseUint(val, 0, 32)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as uint32 for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as uint32 for key: %s. Options: %s\n",
+				val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return uint32(u)
@@ -297,7 +296,7 @@ func expandPath(path string) (string, error) {
 	if path[0] == '~' && (len(path) == 1 || os.IsPathSeparator(path[1])) {
 		usr, err := user.Current()
 		if err != nil {
-			return "", errors.Wrap(err, "Failed to get the home directory of the user")
+			return "", errors.Join(err, errors.New("Failed to get the home directory of the user"))
 		}
 		path = filepath.Join(usr.HomeDir, path[1:])
 	}
@@ -305,7 +304,7 @@ func expandPath(path string) (string, error) {
 	var err error
 	path, err = filepath.Abs(path)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to generate absolute path")
+		return "", errors.Join(err, errors.New("Failed to generate absolute path"))
 	}
 	return path, nil
 }


### PR DESCRIPTION
Trying to get rid of github.com/pkg/errors in OPA and use the stdlib errors instead. This was one of the upstream deps still using this library. If there's a reason for that, let me know 😅 