### PR TITLE
chore: remove github.com/pkg/errors dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html) starting v1.
 
 ## [Unreleased]
 
+**Changed**
+
+- Remove dependency: github.com/pkg/errors (#443)
+
 **Fixed**
 
 - Switch from using a sync.Waitgroup, to closing a channel of struct{} (#442)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da
 	github.com/dustin/go-humanize v1.0.1
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa5
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/z/file.go
+++ b/z/file.go
@@ -7,12 +7,11 @@ package z
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 // MmapFile represents an mmapd file and includes both the buffer to the data
@@ -28,7 +27,7 @@ func OpenMmapFileUsing(fd *os.File, sz int, writable bool) (*MmapFile, error) {
 	filename := fd.Name()
 	fi, err := fd.Stat()
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot stat file: %s", filename)
+		return nil, errors.Join(err, fmt.Errorf("cannot stat file: %s", filename))
 	}
 
 	var rerr error
@@ -36,7 +35,7 @@ func OpenMmapFileUsing(fd *os.File, sz int, writable bool) (*MmapFile, error) {
 	if sz > 0 && fileSize == 0 {
 		// If file is empty, truncate it to sz.
 		if err := fd.Truncate(int64(sz)); err != nil {
-			return nil, errors.Wrapf(err, "error while truncation")
+			return nil, errors.Join(err, errors.New("error while truncation"))
 		}
 		fileSize = int64(sz)
 		rerr = NewFile
@@ -45,7 +44,7 @@ func OpenMmapFileUsing(fd *os.File, sz int, writable bool) (*MmapFile, error) {
 	// fmt.Printf("Mmaping file: %s with writable: %v filesize: %d\n", fd.Name(), writable, fileSize)
 	buf, err := Mmap(fd, writable, fileSize) // Mmap up to file size.
 	if err != nil {
-		return nil, errors.Wrapf(err, "while mmapping %s with size: %d", fd.Name(), fileSize)
+		return nil, errors.Join(err, fmt.Errorf("while mmapping %s with size: %d", fd.Name(), fileSize))
 	}
 
 	if fileSize == 0 {
@@ -68,7 +67,7 @@ func OpenMmapFile(filename string, flag int, maxSz int) (*MmapFile, error) {
 	// fmt.Printf("opening file %s with flag: %v\n", filename, flag)
 	fd, err := os.OpenFile(filename, flag, 0666)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to open: %s", filename)
+		return nil, errors.Join(err, fmt.Errorf("unable to open: %s", filename))
 	}
 	writable := true
 	if flag == os.O_RDONLY {
@@ -196,13 +195,13 @@ func (m *MmapFile) Close(maxSz int64) error {
 func SyncDir(dir string) error {
 	df, err := os.Open(dir)
 	if err != nil {
-		return errors.Wrapf(err, "while opening %s", dir)
+		return errors.Join(err, fmt.Errorf("while opening %s", dir))
 	}
 	if err := df.Sync(); err != nil {
-		return errors.Wrapf(err, "while syncing %s", dir)
+		return errors.Join(err, fmt.Errorf("while syncing %s", dir))
 	}
 	if err := df.Close(); err != nil {
-		return errors.Wrapf(err, "while closing %s", dir)
+		return errors.Join(err, fmt.Errorf("while closing %s", dir))
 	}
 	return nil
 }

--- a/z/flags.go
+++ b/z/flags.go
@@ -6,6 +6,7 @@
 package z
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -15,8 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // SuperFlagHelp makes it really easy to generate command line `--help` output for a SuperFlag. For
@@ -209,9 +208,8 @@ func (sf *SuperFlag) GetBool(opt string) bool {
 	}
 	b, err := strconv.ParseBool(val)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as bool for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as bool for key: %s. Options: %s\n", val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return b
@@ -224,9 +222,8 @@ func (sf *SuperFlag) GetFloat64(opt string) float64 {
 	}
 	f, err := strconv.ParseFloat(val, 64)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as float64 for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as float64 for key: %s. Options: %s\n", val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return f
@@ -239,9 +236,8 @@ func (sf *SuperFlag) GetInt64(opt string) int64 {
 	}
 	i, err := strconv.ParseInt(val, 0, 64)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as int64 for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as int64 for key: %s. Options: %s\n", val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return i
@@ -254,9 +250,8 @@ func (sf *SuperFlag) GetUint64(opt string) uint64 {
 	}
 	u, err := strconv.ParseUint(val, 0, 64)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as uint64 for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as uint64 for key: %s. Options: %s\n", val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return u
@@ -269,9 +264,8 @@ func (sf *SuperFlag) GetUint32(opt string) uint32 {
 	}
 	u, err := strconv.ParseUint(val, 0, 32)
 	if err != nil {
-		err = errors.Wrapf(err,
-			"Unable to parse %s as uint32 for key: %s. Options: %s\n",
-			val, opt, sf)
+		err = errors.Join(err,
+			fmt.Errorf("Unable to parse %s as uint32 for key: %s. Options: %s\n", val, opt, sf))
 		log.Fatalf("%+v", err)
 	}
 	return uint32(u)
@@ -302,7 +296,7 @@ func expandPath(path string) (string, error) {
 	if path[0] == '~' && (len(path) == 1 || os.IsPathSeparator(path[1])) {
 		usr, err := user.Current()
 		if err != nil {
-			return "", errors.Wrap(err, "Failed to get the home directory of the user")
+			return "", errors.Join(err, errors.New("Failed to get the home directory of the user"))
 		}
 		path = filepath.Join(usr.HomeDir, path[1:])
 	}
@@ -310,7 +304,7 @@ func expandPath(path string) (string, error) {
 	var err error
 	path, err = filepath.Abs(path)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to generate absolute path")
+		return "", errors.Join(err, errors.New("Failed to generate absolute path"))
 	}
 	return path, nil
 }


### PR DESCRIPTION
**Description**

As opened before by @anderseknert  in PR (#364)
- Trying to get rid of github.com/pkg/errors in OPA and use the stdlib errors instead. This was one of the upstream deps still using this library. If there's a reason for that, let me know 😅

The PR was stale, so I reopened a new one to be merge, as asked by @mangalaman93 .

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR