### PR TITLE
fix: Remove zerovalue[V].

### DIFF
--- a/store.go
+++ b/store.go
@@ -133,7 +133,7 @@ func (m *lockedMap[V]) setShouldUpdateFn(f updateFn[V]) {
 	m.shouldUpdate = f
 }
 
-func (m *lockedMap[V]) get(key, conflict uint64) (value V, ok bool) {
+func (m *lockedMap[V]) get(key, conflict uint64) (valueR V, okR bool) {
 	m.RLock()
 	item, ok := m.data[key]
 	m.RUnlock()
@@ -191,7 +191,7 @@ func (m *lockedMap[V]) Set(i *Item[V]) {
 	}
 }
 
-func (m *lockedMap[V]) Del(key, conflict uint64) (c uint64, value V) {
+func (m *lockedMap[V]) Del(key, conflict uint64) (c uint64, valueR V) {
 	m.Lock()
 	defer m.Unlock()
 	item, ok := m.data[key]
@@ -210,7 +210,7 @@ func (m *lockedMap[V]) Del(key, conflict uint64) (c uint64, value V) {
 	return item.conflict, item.value
 }
 
-func (m *lockedMap[V]) Update(newItem *Item[V]) (value V, ok bool) {
+func (m *lockedMap[V]) Update(newItem *Item[V]) (valueR V, okR bool) {
 	m.Lock()
 	defer m.Unlock()
 	item, ok := m.data[newItem.Key]


### PR DESCRIPTION
When i added generics in my PR i put the zerovalue to return valid values(since not all values will have nil).
a more elegant solution is just to have paramater returns in the function

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [x] For public APIs, new features, etc., PR on
      [docs repo](https://github.com/dgraph-io/dgraph-docs) staged and linked here

**Instructions**

- The PR title should follow the [Conventional Commits](https://www.conventionalcommits.org/)
  syntax, leading with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- The description should briefly explain what the PR is about. In the case of a bugfix, describe or
  link to the bug.
- In the checklist section, check the boxes in that are applicable, using `[x]` syntax.
  - If not applicable, remove the entire line. Only leave the box unchecked if you intend to come
    back and check the box later.
- Delete the `Instructions` line and everything below it, to indicate you have read and are
  following these instructions. 🙂

Thank you for your contribution to Ristretto!
