### PR TITLE
Add public Cache.Cap() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html) starting v1.
 **Changed**
 
 - Remove dependency: github.com/pkg/errors (#443)
+- Add public Cache.Cap() method
 
 **Fixed**
 

--- a/cache.go
+++ b/cache.go
@@ -489,6 +489,14 @@ func (c *Cache[K, V]) UpdateMaxCost(maxCost int64) {
 	c.cachePolicy.UpdateMaxCost(maxCost)
 }
 
+// Cap returns the remaining cost capacity (MaxCost - Used) of an existing cache.
+func (c *Cache[K, V]) Cap() int64 {
+	if c == nil {
+		return 0
+	}
+	return c.cachePolicy.Cap()
+}
+
 // processItems is ran by goroutines processing the Set buffer.
 func (c *Cache[K, V]) processItems() {
 	startTs := make(map[uint64]time.Time)


### PR DESCRIPTION
**Description**

Currently, there's no way to deduce how much of the max capacity is being used in a cache instance. This adds a new `Cap()` method that enables this. Some cases where this is useful:

* Monitoring the cache usage trend to facilitate better cache sizing
* Decide whether to apply backpressure to data fetching based on the available capacity

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
